### PR TITLE
Add support for Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,8 @@ setup(
     install_requires=[
         'six',
     ],
-    extra_requires={
+    extras_require={
+        ":python_version<'3.4'": ['statistics'],
         'datadog': ['datadog'],
         'statsd': ['statsd'],
     },
@@ -76,6 +77,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)',
         'Natural Language :: English',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36
+envlist = py27,py34,py35,py36
 
 [testenv]
 commands =


### PR DESCRIPTION
Python 2.7 doesn't have the statistics module, so we need to install the
backport library. This fixes setup so that that works with wheels and adds the
necessary tox environment for testing.

Fixes #23