### PR TITLE
Fix timing and histogram in cloudwatch backend

### DIFF
--- a/markus/backends/cloudwatch.py
+++ b/markus/backends/cloudwatch.py
@@ -28,16 +28,11 @@ class CloudwatchMetrics(BackendBase):
 
     This backend doesn't take any options.
 
-    .. Note::
-
-       Datadog doesn't support metrics other than incr (count) and gauge. This
-       backend will send timing and histogram metrics as gauges.
-
     .. seealso::
 
-       http://docs.datadoghq.com/integrations/awslambda/
+       https://docs.datadoghq.com/integrations/amazon_lambda/
 
-       https://www.datadoghq.com/blog/monitoring-lambda-functions-datadog/#toc-beyond-standard-metrics
+       https://docs.datadoghq.com/developers/metrics/#metric-names
 
     """
     def _log(self, metrics_kind, stat, value, tags):
@@ -58,9 +53,10 @@ class CloudwatchMetrics(BackendBase):
         self._log('gauge', stat, value, tags)
 
     def timing(self, stat, value, tags=None):
-        """Does the same thing as gauge"""
-        self._log('gauge', stat, value, tags)
+        """Set a timing"""
+        # NOTE(willkg): timing is a special case of histogram
+        self._log('histogram', stat, value, tags)
 
     def histogram(self, stat, value, tags=None):
-        """Does the same thing as gauge"""
-        self._log('gauge', stat, value, tags)
+        """Set a histogram"""
+        self._log('histogram', stat, value, tags)

--- a/markus/backends/datadog.py
+++ b/markus/backends/datadog.py
@@ -51,7 +51,7 @@ class DatadogMetrics(BackendBase):
 
     .. seealso::
 
-       http://docs.datadoghq.com/guides/metrics/
+       https://docs.datadoghq.com/developers/metrics/
 
     """
     def __init__(self, options):

--- a/markus/backends/statsd.py
+++ b/markus/backends/statsd.py
@@ -56,7 +56,7 @@ class StatsdMetrics(BackendBase):
 
     .. seealso::
 
-       http://statsd.readthedocs.io/en/latest/configure.html
+       https://statsd.readthedocs.io/en/latest/configure.html
 
     """
     def __init__(self, options):

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -26,19 +26,18 @@ class TestCloudwatch:
         assert err == ''
 
     def test_timing(self, capsys):
-        # .timing is a gauge
+        # .timing is a histogram
         ddcm = CloudwatchMetrics({})
 
         ddcm.timing('foo', value=100, tags=['key1:val', 'key2:val'])
         out, err = capsys.readouterr()
-        assert out == 'MONITORING|1488817800|100|gauge|foo|#key1:val,key2:val\n'
+        assert out == 'MONITORING|1488817800|100|histogram|foo|#key1:val,key2:val\n'
         assert err == ''
 
     def test_histogram(self, capsys):
-        # .histogram is a gauge
         ddcm = CloudwatchMetrics({})
 
         ddcm.histogram('foo', value=100, tags=['key1:val', 'key2:val'])
         out, err = capsys.readouterr()
-        assert out == 'MONITORING|1488817800|100|gauge|foo|#key1:val,key2:val\n'
+        assert out == 'MONITORING|1488817800|100|histogram|foo|#key1:val,key2:val\n'
         assert err == ''


### PR DESCRIPTION
Datadog changed their AWS Lambda cloudwatch slurping stuff to support
histogram in addition to count and gauge. This fixes Markus accordingly.

Fixes #31.