### PR TITLE
Update dev requirements, support Python 3.7

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,12 @@
 -e .
 
-datadog==0.16.0
-statsd==3.2.1
+datadog==0.26.0
+statsd==3.3.0
 
-freezegun==0.3.9
-pytest==3.2.1
-pytest-catchlog==1.2.2
+freezegun==0.3.11
+pytest==4.3.0
 pytest-wholenodeid==0.2
 tox==2.6
-twine==1.9.1
-Sphinx==1.6.3
-flake8==3.4.1
+twine==1.13.0
+Sphinx==1.8.4
+flake8==3.7.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,4 +18,7 @@ ignore =
 max-line-length = 100
 
 [tool:pytest]
-filterwarnings = error
+filterwarnings =
+    error
+    # datadog kicks up a DeprecationWarning for collections use.
+    ignore:.*ABCs:DeprecationWarning

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -10,6 +10,7 @@ from markus.backends.logging import LoggingMetrics, LoggingRollupMetrics
 @freeze_time('2017-03-06 16:30:00', tz_offset=0)
 class TestLoggingMetrics:
     def test_incr(self, caplog):
+        caplog.set_level('DEBUG')
         lm = LoggingMetrics({})
 
         lm.incr('foo', value=10, tags=['key1:val', 'key2:val'])
@@ -22,6 +23,7 @@ class TestLoggingMetrics:
         )
 
     def test_gauge(self, caplog):
+        caplog.set_level('DEBUG')
         lm = LoggingMetrics({})
 
         lm.gauge('foo', value=100, tags=['key1:val', 'key2:val'])
@@ -34,6 +36,7 @@ class TestLoggingMetrics:
         )
 
     def test_timing(self, caplog):
+        caplog.set_level('DEBUG')
         lm = LoggingMetrics({})
 
         lm.timing('foo', value=1234, tags=['key1:val', 'key2:val'])
@@ -46,6 +49,7 @@ class TestLoggingMetrics:
         )
 
     def test_histogram(self, caplog):
+        caplog.set_level('DEBUG')
         lm = LoggingMetrics({})
 
         lm.histogram('foo', value=4321, tags=['key1:val', 'key2:val'])
@@ -60,6 +64,7 @@ class TestLoggingMetrics:
 
 class TestLoggingRollupMetrics:
     def test_rollup(self, caplog):
+        caplog.set_level('DEBUG')
         with freeze_time('2017-04-19 12:00:00'):
             lm = LoggingRollupMetrics({})
             lm.incr('foo')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py27,py34,py35,py36,py37
 
 [testenv]
 commands =


### PR DESCRIPTION
The only issue here is that datadog kicks up a `DeprecationWarning`. That's tracked here:

https://github.com/DataDog/datadogpy/issues/338

For now, I added an ignore for that warning. Otherwise this is fine.

Fixes #33