### PR TITLE
rewrite internals to emit records

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,11 @@ History
 * Use ``time.perf_counter()`` if available. Thank you, Mike! (#34)
 * Support Python 3.7 more officially.
 
+**Backwards incompatible changes**
+
+* ``tags`` now defaults to ``[]`` instead of ``None`` which may affect some
+  expected test output.
+
 **Bug fix**
 
 * Drop support for Python 3.4. (#39)

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Then you can use the ``MetricsImplementation`` anywhere in that module::
     def some_long_function(vegetable):
         for veg in vegetable:
             chop_vegetable()
-            metrics.incr('vegetable', 1)
+            metrics.incr('vegetable', value=1)
 
 
 At application startup, configure Markus with the backends you want to use to

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -83,13 +83,10 @@ For example, here's a backend that prints metrics to stdout:
 
     >>> metrics = markus.get_metrics('test')
     >>> metrics.incr('key1')
-    incr foo test.key1 1 tags=None
+    incr foo test.key1 1 tags=[]
 
 
 .. testcleanup:: *
 
    import markus
    markus.configure([])
-
-
-This will print to stdout ``foo incr test.key1 1 None {}``.

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -50,12 +50,12 @@ Writing your own
 2. Implement ``__init__``. It takes a single "options" dict with stuff the
    user configured.
 
-3. Implement ``incr``, ``gauge``, ``timing``, and ``histogram`` and have them
-   do whatever is appropriate in the context of your backend.
+3. Implement ``emit`` and have it do whatever is appropriate in the context of
+   your backend.
 
 
 .. autoclass:: markus.backends.BackendBase
-   :members: __init__, incr, gauge, timing, histogram
+   :members: __init__, emit
 
 
 For example, here's a backend that prints metrics to stdout:
@@ -64,31 +64,26 @@ For example, here's a backend that prints metrics to stdout:
 
     >>> import markus
     >>> from markus.backends import BackendBase
+    >>> from markus.main import MetricsRecord
 
     >>> class StdoutMetrics(BackendBase):
     ...     def __init__(self, options):
     ...         self.prefix = options.get('prefix', '')
     ...
-    ...     def _generate(self, kind, stat, value, tags, **extras):
-    ...         print('%s %s %s %s tags=%s %s' % (kind, self.prefix, stat, value, tags, extras))
-    ...
-    ...     def incr(self, stat, value, tags=None):
-    ...         self._generate('incr', stat, value, tags)
-    ...
-    ...     def gauge(self, stat, value, tags=None):
-    ...         self._generate('gauge', stat, value, tags)
-    ...
-    ...     def timing(self, stat, value, tags=None):
-    ...         self._generate('timing', stat, value, tags)
-    ...
-    ...     def histogram(self, stat, value, tags=None):
-    ...         self._generate('histogram', stat, value, tags)
+    ...     def emit(self, record):
+    ...         print('%s %s %s %s tags=%s' % (
+    ...             record.stat_type,
+    ...             self.prefix,
+    ...             record.key,
+    ...             record.value,
+    ...             record.tags
+    ...         ))
     ...
     >>> markus.configure([{'class': StdoutMetrics, 'options': {'prefix': 'foo'}}], raise_errors=True)
 
     >>> metrics = markus.get_metrics('test')
-    >>> metrics.incr('key1', value=1)
-    incr foo test.key1 1 tags=None {}
+    >>> metrics.incr('key1')
+    incr foo test.key1 1 tags=None
 
 
 .. testcleanup:: *

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -58,7 +58,12 @@ Writing your own
    :members: __init__, emit
 
 
-For example, here's a backend that prints metrics to stdout:
+The records that get emitted are ``markus.main.MetricsRecord`` instances.
+
+.. autoclass:: markus.main.MetricsRecord
+
+
+Here's an example backend that prints metrics to stdout:
 
 .. doctest::
 

--- a/markus/backends/__init__.py
+++ b/markus/backends/__init__.py
@@ -10,18 +10,6 @@ class BackendBase(object):
         """Implement this. The options dict is the user-specified options."""
         self.options = options
 
-    def incr(self, stat, value=1, tags=None):
-        """Implement this. This is a counter-type metric."""
-        raise NotImplementedError
-
-    def gauge(self, stat, value, tags=None):
-        """Implement this. This is a gauge-type metric."""
-        raise NotImplementedError
-
-    def timing(self, stat, value, tags=None):
-        """Implement this. This is a timing-type metric."""
-        raise NotImplementedError
-
-    def histogram(self, stat, value, tags=None):
-        """Implement this. This is a histogram-type metric."""
+    def emit(self, record):
+        """Implement this to emit records."""
         raise NotImplementedError

--- a/markus/backends/cloudwatch.py
+++ b/markus/backends/cloudwatch.py
@@ -36,31 +36,17 @@ class CloudwatchMetrics(BackendBase):
 
     """
 
-    def _log(self, metrics_kind, stat, value, tags):
+    def emit(self, record):
+        stat_type_to_kind = {
+            'incr': 'count',
+            'gauge': 'gauge',
+            'timing': 'histogram',
+            'histogram': 'histogram'
+        }
         print('MONITORING|%(timestamp)s|%(value)s|%(kind)s|%(stat)s|%(tags)s' % {
             'timestamp': int(time.time()),
-            'kind': metrics_kind,
-            'stat': stat,
-            'value': value,
-            'tags': ('#%s' % ','.join(tags)) if tags else ''
+            'kind': stat_type_to_kind[record.stat_type],
+            'stat': record.key,
+            'value': record.value,
+            'tags': ('#%s' % ','.join(record.tags)) if record.tags else ''
         })
-
-    def incr(self, stat, value=1, tags=None):
-        """Increment a counter."""
-        self._log('count', stat, value, tags)
-
-    def gauge(self, stat, value, tags=None):
-        """Set a gauge."""
-        self._log('gauge', stat, value, tags)
-
-    def timing(self, stat, value, tags=None):
-        """Set a timing.
-
-        Note: Does the same thing as histogram.
-
-        """
-        self._log('histogram', stat, value, tags)
-
-    def histogram(self, stat, value, tags=None):
-        """Set a histogram."""
-        self._log('histogram', stat, value, tags)

--- a/markus/backends/datadog.py
+++ b/markus/backends/datadog.py
@@ -69,18 +69,12 @@ class DatadogMetrics(BackendBase):
     def _get_client(self, host, port, namespace):
         return DogStatsd(host=host, port=port, namespace=namespace)
 
-    def incr(self, stat, value=1, tags=None):
-        """Increment a counter."""
-        self.client.increment(metric=stat, value=value, tags=tags)
-
-    def gauge(self, stat, value, tags=None):
-        """Set a gauge."""
-        self.client.gauge(metric=stat, value=value, tags=tags)
-
-    def timing(self, stat, value, tags=None):
-        """Measure a timing for statistical distribution."""
-        self.client.timing(metric=stat, value=value, tags=tags)
-
-    def histogram(self, stat, value, tags=None):
-        """Measure a value for statistical distribution."""
-        self.client.histogram(metric=stat, value=value, tags=tags)
+    def emit(self, record):
+        stat_type_to_fun = {
+            'incr': self.client.increment,
+            'gauge': self.client.gauge,
+            'timing': self.client.timing,
+            'histogram': self.client.histogram,
+        }
+        metrics_fun = stat_type_to_fun[record.stat_type]
+        metrics_fun(metric=record.key, value=record.value, tags=record.tags)

--- a/markus/main.py
+++ b/markus/main.py
@@ -143,7 +143,7 @@ class MetricsRecord:
         self.stat_type = stat_type
         self.key = key
         self.value = value
-        self.tags = tags
+        self.tags = tags or []
 
     def __repr__(self):
         return '<MetricsRecord %r %r %r %r>' % (self.stat_type, self.key, self.value, self.tags)

--- a/markus/main.py
+++ b/markus/main.py
@@ -13,6 +13,7 @@ import six
 
 
 NOT_ALPHANUM_RE = re.compile(r'[^a-z0-9_\.]', re.I)
+CONSECUTIVE_PERIODS_RE = re.compile(r'\.+')
 
 
 logger = logging.getLogger(__name__)
@@ -145,28 +146,27 @@ class MetricsInterface:
 
     """
 
-    def __init__(self, name):
+    def __init__(self, prefix):
         """Create a MetricsInterface.
 
-        :arg str name: Use alphanumeric characters and underscore and period.
+        :arg str prefix: Use alphanumeric characters and underscore and period.
             Anything else gets converted to a period. Sequences of periods get
             collapsed to a single period.
 
+            The prefix is prepended to all keys emitted by this metrics
+            interface.
+
         """
         # Convert all bad characters to .
-        name = NOT_ALPHANUM_RE.sub('.', name)
+        prefix = NOT_ALPHANUM_RE.sub('.', prefix)
         # Collapse sequences of . to a single .
-        while True:
-            new_name = name.replace('..', '.')
-            if new_name == name:
-                break
-            name = new_name
+        prefix = CONSECUTIVE_PERIODS_RE.sub('.', prefix)
         # Remove . at beginning and end
-        self.name = name.strip('.')
+        self.prefix = prefix.strip('.')
 
     def _full_stat(self, stat):
-        if self.name:
-            return self.name + '.' + stat
+        if self.prefix:
+            return self.prefix + '.' + stat
         else:
             return stat
 
@@ -394,9 +394,9 @@ class MetricsInterface:
 
 
 def get_metrics(thing, extra=''):
-    """Return MetricsInterface instance with specified name.
+    """Return MetricsInterface instance with specified prefix.
 
-    The name is used as the prefix for all keys generated with this
+    The prefix is prepended to all keys emitted with this
     :py:class:`markus.main.MetricsInterface`.
 
     The :py:class:`markus.main.MetricsInterface` is not tied to metrics
@@ -404,12 +404,12 @@ def get_metrics(thing, extra=''):
     us to create :py:class:`markus.main.MetricsInterface` classes without
     having to worry about bootstrapping order of the app.
 
-    :arg class/instance/str thing: The name to use as a key prefix.
+    :arg class/instance/str thing: The prefix to use for keys.
 
         If this is a class, it uses the dotted Python path. If this is an
         instance, it uses the dotted Python path plus ``str(instance)``.
 
-    :arg str extra: Any extra bits to add to the end of the name.
+    :arg str extra: Any extra bits to add to the end of the prefix.
 
     :returns: a ``MetricsInterface`` instance
 
@@ -417,7 +417,7 @@ def get_metrics(thing, extra=''):
 
     >>> from markus import get_metrics
 
-    Create a MetricsInterface with the name "myapp" and generate a count with
+    Create a MetricsInterface with the prefix "myapp" and generate a count with
     stat "myapp.thing1" and value 1:
 
     >>> metrics = get_metrics('myapp')
@@ -437,13 +437,13 @@ def get_metrics(thing, extra=''):
     Create a prefix of the class path plus some identifying information:
 
     >>> class Foo:
-    ...     def __init__(self, myname):
-    ...         self.metrics = get_metrics(self, extra=myname)
+    ...     def __init__(self, myprefix):
+    ...         self.metrics = get_metrics(self, extra=myprefix)
     ...
     >>> foo = Foo('jim')
 
     Assume that ``Foo`` is defined in the ``myapp`` module. Then this will
-    generate the name ``myapp.Foo.jim``.
+    generate the prefix ``myapp.Foo.jim``.
 
     """
     thing = thing or ''

--- a/markus/main.py
+++ b/markus/main.py
@@ -137,7 +137,15 @@ def configure(backends, raise_errors=False):
 
 
 class MetricsRecord:
-    """Record for a single emitted metric."""
+    """Record for a single emitted metric.
+
+    :attribute stat_type: the type of the stat ('incr', 'gauge', 'timing',
+        'histogram')
+    :attribute key: the full key for this record
+    :attribute value: the value for this record
+    :attribute tags: list of tag strings
+
+    """
 
     def __init__(self, stat_type, key, value, tags):
         self.stat_type = stat_type
@@ -202,6 +210,8 @@ class MetricsInterface:
 
             For example ``['env:stage', 'compressed:yes']``.
 
+            To pass no tags, either pass an empty list or ``None``.
+
         For example:
 
         >>> import markus
@@ -234,6 +244,8 @@ class MetricsInterface:
             metrics for analysis.
 
             For example ``['env:stage', 'compressed:yes']``.
+
+            To pass no tags, either pass an empty list or ``None``.
 
         For example:
 
@@ -275,6 +287,8 @@ class MetricsInterface:
             metrics for analysis.
 
             For example ``['env:stage', 'compressed:yes']``.
+
+            To pass no tags, either pass an empty list or ``None``.
 
         For example:
 
@@ -326,6 +340,8 @@ class MetricsInterface:
 
             For example ``['env:stage', 'compressed:yes']``.
 
+            To pass no tags, either pass an empty list or ``None``.
+
         For example:
 
         >>> import time
@@ -363,6 +379,8 @@ class MetricsInterface:
 
             For example ``['env:stage', 'compressed:yes']``.
 
+            To pass no tags, either pass an empty list or ``None``.
+
         For example:
 
         >>> mymetrics = get_metrics(__name__)
@@ -397,6 +415,8 @@ class MetricsInterface:
             metrics for analysis.
 
             For example ``['env:stage', 'compressed:yes']``.
+
+            To pass no tags, either pass an empty list or ``None``.
 
         For example:
 

--- a/markus/testing.py
+++ b/markus/testing.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from markus import INCR, GAUGE, TIMING, HISTOGRAM
+from markus import INCR, GAUGE, TIMING, HISTOGRAM  # noqa
 
 from markus.main import _override_metrics
 

--- a/markus/testing.py
+++ b/markus/testing.py
@@ -38,21 +38,8 @@ class MetricsMock:
     def _add_record(self, fun_name, stat, value, tags):
         self.records.append((fun_name, stat, value, tags))
 
-    def incr(self, stat, value=1, tags=None):
-        """Increment a counter."""
-        self._add_record(INCR, stat, value, tags)
-
-    def gauge(self, stat, value, tags=None):
-        """Set a gauge."""
-        self._add_record(GAUGE, stat, value, tags)
-
-    def timing(self, stat, value, tags=None):
-        """Measure a timing for statistical distribution."""
-        self._add_record(TIMING, stat, value, tags)
-
-    def histogram(self, stat, value, tags=None):
-        """Measure a value for statistical distribution."""
-        self._add_record(HISTOGRAM, stat, value, tags)
+    def emit(self, record):
+        self._add_record(record.stat_type, record.key, record.value, record.tags)
 
     def __enter__(self):
         self.records = []

--- a/markus/utils.py
+++ b/markus/utils.py
@@ -40,6 +40,7 @@ def generate_tag(key, value=None):
 
     Examples:
 
+    >>> from markus.utils import generate_tag
     >>> generate_tag('yellow')
     'yellow'
     >>> generate_tag('rule', 'is_yellow')
@@ -48,6 +49,7 @@ def generate_tag(key, value=None):
     Example with ``incr``:
 
     >>> import markus
+    >>> from markus.utils import generate_tag
     >>> mymetrics = markus.get_metrics(__name__)
 
     >>> mymetrics.incr('somekey', value=1,

--- a/tests/test_cloudwatch.py
+++ b/tests/test_cloudwatch.py
@@ -5,39 +5,40 @@
 from freezegun import freeze_time
 
 from markus.backends.cloudwatch import CloudwatchMetrics
+from markus.main import MetricsRecord
 
 
 @freeze_time('2017-03-06 16:30:00', tz_offset=0)
 class TestCloudwatch:
     def test_incr(self, capsys):
+        rec = MetricsRecord('incr', key='foo', value=10, tags=['key1:val', 'key2:val'])
         ddcm = CloudwatchMetrics({})
-
-        ddcm.incr('foo', value=10, tags=['key1:val', 'key2:val'])
+        ddcm.emit(rec)
         out, err = capsys.readouterr()
         assert out == 'MONITORING|1488817800|10|count|foo|#key1:val,key2:val\n'
         assert err == ''
 
     def test_gauge(self, capsys):
+        rec = MetricsRecord('gauge', key='foo', value=100, tags=['key1:val', 'key2:val'])
         ddcm = CloudwatchMetrics({})
-
-        ddcm.gauge('foo', value=100, tags=['key1:val', 'key2:val'])
+        ddcm.emit(rec)
         out, err = capsys.readouterr()
         assert out == 'MONITORING|1488817800|100|gauge|foo|#key1:val,key2:val\n'
         assert err == ''
 
     def test_timing(self, capsys):
         # .timing is a histogram
+        rec = MetricsRecord('timing', key='foo', value=100, tags=['key1:val', 'key2:val'])
         ddcm = CloudwatchMetrics({})
-
-        ddcm.timing('foo', value=100, tags=['key1:val', 'key2:val'])
+        ddcm.emit(rec)
         out, err = capsys.readouterr()
         assert out == 'MONITORING|1488817800|100|histogram|foo|#key1:val,key2:val\n'
         assert err == ''
 
     def test_histogram(self, capsys):
+        rec = MetricsRecord('histogram', key='foo', value=100, tags=['key1:val', 'key2:val'])
         ddcm = CloudwatchMetrics({})
-
-        ddcm.histogram('foo', value=100, tags=['key1:val', 'key2:val'])
+        ddcm.emit(rec)
         out, err = capsys.readouterr()
         assert out == 'MONITORING|1488817800|100|histogram|foo|#key1:val,key2:val\n'
         assert err == ''

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -5,6 +5,7 @@
 import pytest
 
 from markus.backends import datadog
+from markus.main import MetricsRecord
 
 
 class MockDogStatsd(object):
@@ -73,10 +74,9 @@ def test_options(mockdogstatsd):
 
 
 def test_incr(mockdogstatsd):
+    rec = MetricsRecord('incr', key='foo', value=10, tags=['key1:val'])
     ddm = datadog.DatadogMetrics({})
-
-    ddm.incr('foo', value=10, tags=['key1:val'])
-
+    ddm.emit(rec)
     assert (
         ddm.client.calls ==
         [('increment', (), {'metric': 'foo', 'value': 10, 'tags': ['key1:val']})]
@@ -84,10 +84,9 @@ def test_incr(mockdogstatsd):
 
 
 def test_gauge(mockdogstatsd):
+    rec = MetricsRecord('gauge', key='foo', value=100, tags=['key1:val'])
     ddm = datadog.DatadogMetrics({})
-
-    ddm.gauge('foo', value=100, tags=['key1:val'])
-
+    ddm.emit(rec)
     assert (
         ddm.client.calls ==
         [('gauge', (), {'metric': 'foo', 'value': 100, 'tags': ['key1:val']})]
@@ -95,10 +94,9 @@ def test_gauge(mockdogstatsd):
 
 
 def test_timing(mockdogstatsd):
+    rec = MetricsRecord('timing', key='foo', value=1234, tags=['key1:val'])
     ddm = datadog.DatadogMetrics({})
-
-    ddm.timing('foo', value=1234, tags=['key1:val'])
-
+    ddm.emit(rec)
     assert (
         ddm.client.calls ==
         [('timing', (), {'metric': 'foo', 'value': 1234, 'tags': ['key1:val']})]
@@ -106,10 +104,9 @@ def test_timing(mockdogstatsd):
 
 
 def test_histogram(mockdogstatsd):
+    rec = MetricsRecord('histogram', key='foo', value=4321, tags=['key1:val'])
     ddm = datadog.DatadogMetrics({})
-
-    ddm.histogram('foo', value=4321, tags=['key1:val'])
-
+    ddm.emit(rec)
     assert (
         ddm.client.calls ==
         [('histogram', (), {'metric': 'foo', 'value': 4321, 'tags': ['key1:val']})]

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -47,7 +47,7 @@ def test_incr(metricsmock):
     assert (
         mm.get_records() ==
         [
-            ('incr', 'thing.foo', 5, None)
+            ('incr', 'thing.foo', 5, [])
         ]
     )
 
@@ -61,7 +61,7 @@ def test_gauge(metricsmock):
     assert (
         mm.get_records() ==
         [
-            ('gauge', 'thing.foo', 10, None)
+            ('gauge', 'thing.foo', 10, [])
         ]
     )
 
@@ -75,7 +75,7 @@ def test_timing(metricsmock):
     assert (
         mm.get_records() ==
         [
-            ('timing', 'thing.foo', 1234, None)
+            ('timing', 'thing.foo', 1234, [])
         ]
     )
 
@@ -89,7 +89,7 @@ def test_histogram(metricsmock):
     assert (
         mm.get_records() ==
         [
-            ('histogram', 'thing.foo', 4321, None)
+            ('histogram', 'thing.foo', 4321, [])
         ]
     )
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -16,7 +16,7 @@ def metricsmock():
     ('...ab..c...', 'ab.c'),
 ])
 def test_get_metrics_fix_name(prefix, expected):
-    assert get_metrics(prefix).prefix== expected
+    assert get_metrics(prefix).prefix == expected
 
 
 class Foo(object):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,14 +9,14 @@ def metricsmock():
     return MetricsMock()
 
 
-@pytest.mark.parametrize('name, expected', [
+@pytest.mark.parametrize('prefix, expected', [
     ('', ''),
     ('.', ''),
     ('abc(123)', 'abc.123'),
     ('...ab..c...', 'ab.c'),
 ])
-def test_get_metrics_fix_name(name, expected):
-    assert get_metrics(name).name == expected
+def test_get_metrics_fix_name(prefix, expected):
+    assert get_metrics(prefix).prefix== expected
 
 
 class Foo(object):
@@ -35,7 +35,7 @@ class Foo(object):
     ('foo', 'namespace1', 'foo.namespace1'),
 ])
 def test_get_metrics(thing, extra, expected):
-    assert get_metrics(thing, extra=extra).name == expected
+    assert get_metrics(thing, extra=extra).prefix == expected
 
 
 def test_incr(metricsmock):

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -5,6 +5,7 @@
 import pytest
 
 from markus.backends import statsd
+from markus.main import MetricsRecord
 
 
 class MockStatsd(object):
@@ -77,10 +78,9 @@ def test_options(mockstatsd):
 
 
 def test_incr(mockstatsd):
+    rec = MetricsRecord('incr', key='foo', value=10, tags=['key1:val'])
     ddm = statsd.StatsdMetrics({})
-
-    ddm.incr('foo', value=10, tags=['key1:val'])
-
+    ddm.emit(rec)
     assert (
         ddm.client.calls ==
         [('incr', (), {'stat': 'foo', 'count': 10})]
@@ -88,10 +88,9 @@ def test_incr(mockstatsd):
 
 
 def test_gauge(mockstatsd):
+    rec = MetricsRecord('gauge', key='foo', value=100, tags=['key1:val'])
     ddm = statsd.StatsdMetrics({})
-
-    ddm.gauge('foo', value=100, tags=['key1:val'])
-
+    ddm.emit(rec)
     assert (
         ddm.client.calls ==
         [('gauge', (), {'stat': 'foo', 'value': 100})]
@@ -99,10 +98,9 @@ def test_gauge(mockstatsd):
 
 
 def test_timing(mockstatsd):
+    rec = MetricsRecord('timing', key='foo', value=1234, tags=['key1:val'])
     ddm = statsd.StatsdMetrics({})
-
-    ddm.timing('foo', value=1234, tags=['key1:val'])
-
+    ddm.emit(rec)
     assert (
         ddm.client.calls ==
         [('timing', (), {'stat': 'foo', 'delta': 1234})]
@@ -110,10 +108,9 @@ def test_timing(mockstatsd):
 
 
 def test_histogram(mockstatsd):
+    rec = MetricsRecord('histogram', key='foo', value=4321, tags=['key1:val'])
     ddm = statsd.StatsdMetrics({})
-
-    ddm.histogram('foo', value=4321, tags=['key1:val'])
-
+    ddm.emit(rec)
     assert (
         ddm.client.calls ==
         [('timing', (), {'stat': 'foo', 'delta': 4321})]


### PR DESCRIPTION
This redoes the connections between the MetricsInterface and the backends such that the interface emits MetricsRecords. This reduces a lot of redundancy across the codebase and simplifies it to a single channel.

Fixes #44