### PR TITLE
Add assertion helpers to MetricsMock

### DIFF
--- a/markus/testing.py
+++ b/markus/testing.py
@@ -96,3 +96,51 @@ class MetricsMock:
     def clear_records(self):
         """Clear the records list."""
         self.records = []
+
+    def assert_incr(self, stat, value=None, tags=None):
+        """Asserts an incr was emitted at least once."""
+        assert len(self.filter_records(INCR, stat=stat, value=value, tags=tags)) >= 1
+
+    def assert_incr_once(self, stat, value=None, tags=None):
+        """Asserts an incr was emitted exactly once."""
+        assert len(self.filter_records(INCR, stat=stat, value=value, tags=tags)) == 1
+
+    def assert_not_incr(self, stat, value=None, tags=None):
+        """Asserts an incr was not emitted."""
+        assert len(self.filter_records(INCR, stat=stat, value=value, tags=tags)) == 0
+
+    def assert_gauge(self, stat, value=None, tags=None):
+        """Asserts a gauge was emitted at least once."""
+        assert len(self.filter_records(GAUGE, stat=stat, value=value, tags=tags)) >= 1
+
+    def assert_gauge_once(self, stat, value=None, tags=None):
+        """Asserts a gauge was emitted exactly once."""
+        assert len(self.filter_records(GAUGE, stat=stat, value=value, tags=tags)) == 1
+
+    def assert_not_gauge(self, stat, value=None, tags=None):
+        """Asserts a gauge was not emitted."""
+        assert len(self.filter_records(GAUGE, stat=stat, value=value, tags=tags)) == 0
+
+    def assert_timing(self, stat, value=None, tags=None):
+        """Asserts a timing was emitted at least once."""
+        assert len(self.filter_records(TIMING, stat=stat, value=value, tags=tags)) >= 1
+
+    def assert_timing_once(self, stat, value=None, tags=None):
+        """Asserts a timing was emitted exactly once."""
+        assert len(self.filter_records(TIMING, stat=stat, value=value, tags=tags)) == 1
+
+    def assert_not_timing(self, stat, value=None, tags=None):
+        """Asserts a timing was not emitted."""
+        assert len(self.filter_records(TIMING, stat=stat, value=value, tags=tags)) == 0
+
+    def assert_histogram(self, stat, value=None, tags=None):
+        """Asserts a histogram was emitted at least once."""
+        assert len(self.filter_records(HISTOGRAM, stat=stat, value=value, tags=tags)) >= 1
+
+    def assert_histogram_once(self, stat, value=None, tags=None):
+        """Asserts a histogram was emitted exactly once."""
+        assert len(self.filter_records(HISTOGRAM, stat=stat, value=value, tags=tags)) == 1
+
+    def assert_not_histogram(self, stat, value=None, tags=None):
+        """Asserts a histogram was not emitted."""
+        assert len(self.filter_records(HISTOGRAM, stat=stat, value=value, tags=tags)) == 0

--- a/markus/testing.py
+++ b/markus/testing.py
@@ -97,15 +97,15 @@ class MetricsMock:
         """Clear the records list."""
         self.records = []
 
-    def assert_incr(self, stat, value=None, tags=None):
+    def assert_incr(self, stat, value=1, tags=None):
         """Asserts an incr was emitted at least once."""
         assert len(self.filter_records(INCR, stat=stat, value=value, tags=tags)) >= 1
 
-    def assert_incr_once(self, stat, value=None, tags=None):
+    def assert_incr_once(self, stat, value=1, tags=None):
         """Asserts an incr was emitted exactly once."""
         assert len(self.filter_records(INCR, stat=stat, value=value, tags=tags)) == 1
 
-    def assert_not_incr(self, stat, value=None, tags=None):
+    def assert_not_incr(self, stat, value=1, tags=None):
         """Asserts an incr was not emitted."""
         assert len(self.filter_records(INCR, stat=stat, value=value, tags=tags)) == 0
 

--- a/tests/test_mock.py
+++ b/tests/test_mock.py
@@ -5,6 +5,8 @@
 import markus
 from markus.testing import MetricsMock
 
+import pytest
+
 
 class TestMetricsMock:
     """Verify the MetricsMock works as advertised"""
@@ -129,3 +131,79 @@ class TestMetricsMock:
             assert mm.has_record(fun_name="incr", stat="foobar.key1", value=1)
 
             assert not mm.has_record(fun_name="incr", stat="foobar.key1", value=5)
+
+    def test_incr_helpers(self):
+        with MetricsMock() as mm:
+            markus.configure([{"class": "markus.backends.logging.LoggingMetrics"}])
+            mymetrics = markus.get_metrics("foobar")
+            mymetrics.incr("key1", value=1)
+            mymetrics.incr("keymultiple", value=1)
+            mymetrics.incr("keymultiple", value=1)
+
+            mm.assert_incr(stat="foobar.key1")
+
+            mm.assert_incr_once(stat="foobar.key1")
+            with pytest.raises(AssertionError):
+                mm.assert_incr_once(stat="foobar.keymultiple")
+
+            mm.assert_not_incr(stat="foobar.keynot")
+            mm.assert_not_incr(stat="foobar.key1", value=5)
+            with pytest.raises(AssertionError):
+                mm.assert_not_incr(stat="foobar.key1")
+
+    def test_gauge_helpers(self):
+        with MetricsMock() as mm:
+            markus.configure([{"class": "markus.backends.logging.LoggingMetrics"}])
+            mymetrics = markus.get_metrics("foobar")
+            mymetrics.gauge("key1", value=5)
+            mymetrics.gauge("keymultiple", value=5)
+            mymetrics.gauge("keymultiple", value=5)
+
+            mm.assert_gauge(stat="foobar.key1")
+
+            mm.assert_gauge_once(stat="foobar.key1")
+            with pytest.raises(AssertionError):
+                mm.assert_gauge_once(stat="foobar.keymultiple")
+
+            mm.assert_not_gauge(stat="foobar.keynot")
+            mm.assert_not_gauge(stat="foobar.key1", value=10)
+            with pytest.raises(AssertionError):
+                mm.assert_not_gauge(stat="foobar.key1")
+
+    def test_timing_helpers(self):
+        with MetricsMock() as mm:
+            markus.configure([{"class": "markus.backends.logging.LoggingMetrics"}])
+            mymetrics = markus.get_metrics("foobar")
+            mymetrics.timing("key1", value=1)
+            mymetrics.timing("keymultiple", value=1)
+            mymetrics.timing("keymultiple", value=1)
+
+            mm.assert_timing(stat="foobar.key1")
+
+            mm.assert_timing_once(stat="foobar.key1")
+            with pytest.raises(AssertionError):
+                mm.assert_timing_once(stat="foobar.keymultiple")
+
+            mm.assert_not_timing(stat="foobar.keynot")
+            mm.assert_not_timing(stat="foobar.key1", value=5)
+            with pytest.raises(AssertionError):
+                mm.assert_not_timing(stat="foobar.key1")
+
+    def test_histogram_helpers(self):
+        with MetricsMock() as mm:
+            markus.configure([{"class": "markus.backends.logging.LoggingMetrics"}])
+            mymetrics = markus.get_metrics("foobar")
+            mymetrics.histogram("key1", value=1)
+            mymetrics.histogram("keymultiple", value=1)
+            mymetrics.histogram("keymultiple", value=1)
+
+            mm.assert_histogram(stat="foobar.key1")
+
+            mm.assert_histogram_once(stat="foobar.key1")
+            with pytest.raises(AssertionError):
+                mm.assert_histogram_once(stat="foobar.keymultiple")
+
+            mm.assert_not_histogram(stat="foobar.keynot")
+            mm.assert_not_histogram(stat="foobar.key1", value=5)
+            with pytest.raises(AssertionError):
+                mm.assert_not_histogram(stat="foobar.key1")


### PR DESCRIPTION
This adds a set of assertion helpers to make testing code more concise: `assert_incr`, `assert_incr_once`, `assert_not_incr`, and gauge, timing, and histogram equivalents.

Before:
```
assert metricsmock.has_record("incr", "key1", value=1)
assert len(metricsmock.filter_records("incr", "key1")) == 1
```
After:
```
metricsmock.assert_incr("key1", value=1)
metricsmock.assert_incr_once("key1", value=1)
```

Fixes #68 