### PR TITLE
pyupgrade pass

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Markus documentation build configuration file, created by
 # sphinx-quickstart on Fri Apr  7 16:22:43 2017.
@@ -50,9 +49,9 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = u"Markus"
-copyright = u"2017-2019, Will Kahn-Greene"
-author = u"Will Kahn-Greene"
+project = "Markus"
+copyright = "2017-2021, Will Kahn-Greene"
+author = "Will Kahn-Greene"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -134,7 +133,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "Markus.tex", u"Markus Documentation", u"Will Kahn-Greene", "manual")
+    (master_doc, "Markus.tex", "Markus Documentation", "Will Kahn-Greene", "manual")
 ]
 
 
@@ -142,7 +141,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "markus", u"Markus Documentation", [author], 1)]
+man_pages = [(master_doc, "markus", "Markus Documentation", [author], 1)]
 
 
 # -- Options for Texinfo output -------------------------------------------
@@ -154,7 +153,7 @@ texinfo_documents = [
     (
         master_doc,
         "Markus",
-        u"Markus Documentation",
+        "Markus Documentation",
         author,
         "Markus",
         "One line description of project.",

--- a/markus/backends/__init__.py
+++ b/markus/backends/__init__.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 
-class BackendBase(object):
+class BackendBase:
     """Markus Backend superclass that defines API backends should follow."""
 
     def __init__(self, options=None, filters=None):

--- a/markus/backends/datadog.py
+++ b/markus/backends/datadog.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 
 import logging
 

--- a/markus/backends/logging.py
+++ b/markus/backends/logging.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 
 import datetime
 import logging

--- a/markus/backends/statsd.py
+++ b/markus/backends/statsd.py
@@ -2,7 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-from __future__ import absolute_import
 
 import logging
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ class PyTest(TestCommand):
 def get_version():
     fn = os.path.join("markus", "__init__.py")
     vsre = r"""^__version__ = ['"]([^'"]*)['"]"""
-    version_file = open(fn, "rt").read()
+    version_file = open(fn).read()
     return re.search(vsre, version_file, re.M).group(1)
 
 

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -8,7 +8,7 @@ from markus.backends import datadog
 from markus.main import MetricsFilter, MetricsRecord
 
 
-class MockDogStatsd(object):
+class MockDogStatsd:
     def __init__(self, *args, **kwargs):
         self.initargs = args
         self.initkwargs = kwargs

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -17,7 +17,7 @@ def test_get_metrics_fix_name(prefix, expected):
     assert get_metrics(prefix).prefix == expected
 
 
-class Foo(object):
+class Foo:
     pass
 
 

--- a/tests/test_statsd.py
+++ b/tests/test_statsd.py
@@ -8,7 +8,7 @@ from markus.backends import statsd
 from markus.main import MetricsFilter, MetricsRecord
 
 
-class MockStatsd(object):
+class MockStatsd:
     def __init__(self, *args, **kwargs):
         self.initargs = args
         self.initkwargs = kwargs


### PR DESCRIPTION
* remove `# -*- coding: utf-8 -*-` lines
* remove unicode literals
* remove object subclassing
* remove `from __future__` imports