### PR TITLE
Add print_records() call on assertion failure (#74)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,29 @@
 History
 =======
 
+3.0.0 (In development)
+----------------------
+
+**Features**
+
+* Added support for Python 3.9 (#79). Thank you, Brady!
+
+* Changed ``assert_*`` helper methods on :py:class:`markus.testing.MetricsMock`
+  to print the records to stdout if the assertion fails. This can save some
+  time debugging failing tests. (#74)
+
+**Bug fixes**
+
+**Backwards incompatible changes**
+
+* Dropped support for Python 3.5 (#78). Thank you, Brady!
+
+* :py:meth:`markus.testing.MetricsMock.get_records` and
+  :py:meth:`markus.testing.MetricsMock.filter_records` return
+  :py:class:`markus.main.MetricsRecord` instances now. This might require
+  you to rewrite/update tests that use the ``MetricsMock``.
+
+
 2.2.0 (April 15th, 2020)
 ------------------------
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -2,8 +2,17 @@
 Testing with Markus
 ===================
 
-Markus comes with a ``MetricsMock`` that makes it easier to write tests and
-assert things about generated metrics.
+Markus comes with a :py:class:`markus.testing.MetricsMock` that makes it easier
+to write tests and assert things about generated metrics.
+
+When activating the :py:class:`markus.testing.MetricsMock` context, it becomes
+a backend for all emitted metrics. It'll contains a list of metrics emitted.
+You can assert things about the metrics collected.
+
+There are a set of ``assert_*`` helper methods for simplifying that code, but
+you can also use :py:meth:`markus.testing.MetricsMock.filter_records`
+directly.
+
 
 .. autoclass:: markus.testing.MetricsMock
    :members:

--- a/markus/__init__.py
+++ b/markus/__init__.py
@@ -25,4 +25,4 @@ __email__ = "willkg@mozilla.com"
 # yyyymmdd
 __releasedate__ = ""
 # x.y.z or x.y.z.dev0 -- semver
-__version__ = "2.2.1.dev0"
+__version__ = "3.0.0.dev0"

--- a/markus/main.py
+++ b/markus/main.py
@@ -174,11 +174,21 @@ class MetricsRecord:
         self.tags = tags or []
 
     def __repr__(self):
-        return "<MetricsRecord %r %r %r %r>" % (
-            self.stat_type,
-            self.key,
-            self.value,
-            self.tags,
+        return (
+            f"<MetricsRecord "
+            f"type={self.stat_type} "
+            f"key={self.key} "
+            f"value={self.value} "
+            f"tags={self.tags!r}>"
+        )
+
+    def __eq__(self, obj):
+        return (
+            isinstance(obj, MetricsRecord)
+            and obj.stat_type == self.stat_type
+            and obj.key == self.key
+            and obj.value == self.value
+            and obj.tags == self.tags
         )
 
     def __copy__(self):

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,6 +1,7 @@
 import pytest
 
 from markus import get_metrics
+from markus.main import MetricsRecord
 from markus.testing import MetricsMock
 
 
@@ -44,7 +45,7 @@ def test_incr(metricsmock):
     with metricsmock as mm:
         metrics.incr("foo", value=5)
 
-    assert mm.get_records() == [("incr", "thing.foo", 5, [])]
+    assert mm.get_records() == [MetricsRecord("incr", "thing.foo", 5, [])]
 
 
 def test_gauge(metricsmock):
@@ -53,7 +54,7 @@ def test_gauge(metricsmock):
     with metricsmock as mm:
         metrics.gauge("foo", value=10)
 
-    assert mm.get_records() == [("gauge", "thing.foo", 10, [])]
+    assert mm.get_records() == [MetricsRecord("gauge", "thing.foo", 10, [])]
 
 
 def test_timing(metricsmock):
@@ -62,7 +63,7 @@ def test_timing(metricsmock):
     with metricsmock as mm:
         metrics.timing("foo", value=1234)
 
-    assert mm.get_records() == [("timing", "thing.foo", 1234, [])]
+    assert mm.get_records() == [MetricsRecord("timing", "thing.foo", 1234, [])]
 
 
 def test_histogram(metricsmock):
@@ -71,7 +72,7 @@ def test_histogram(metricsmock):
     with metricsmock as mm:
         metrics.histogram("foo", value=4321)
 
-    assert mm.get_records() == [("histogram", "thing.foo", 4321, [])]
+    assert mm.get_records() == [MetricsRecord("histogram", "thing.foo", 4321, [])]
 
 
 def test_timer_contextmanager(metricsmock):


### PR DESCRIPTION
If you're using one of the `assert_*` helper methods on `MetricsMock` and the assertion fails, then this will make it print the metrics records that were captured.

Fixes #74 