### PR TITLE
Improve documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,8 +49,9 @@ Quick start
 ===========
 
 Similar to using the logging library, every Python module can create a
-``MetricsInterface`` (loosely equivalent to a Python logging logger) at any time
-including at module import time and use that to generate metrics.
+:py:class:`markus.main.MetricsInterface` (loosely equivalent to a Python
+logging logger) at any time including at module import time and use that to
+generate metrics.
 
 For example::
 
@@ -59,17 +60,18 @@ For example::
     metrics = markus.get_metrics(__name__)
 
 
-Creating a ``MetricsImplementation`` using ``__name__`` will cause it to
-generate all stats keys with a prefix determined from ``__name__`` which
-is a dotted Python path to that module.
+Creating a :py:class:`markus.main.MetricsInterface` using ``__name__``
+will cause it to generate all stats keys with a prefix determined from
+``__name__`` which is a dotted Python path to that module.
 
-Then you can use the ``MetricsImplementation`` anywhere in that module::
+Then you can use the :py:class:`markus.main.MetricsInterface` anywhere in that
+module::
 
-    @metrics.timer_decorator('chopping_vegetables')
+    @metrics.timer_decorator("chopping_vegetables")
     def some_long_function(vegetable):
         for veg in vegetable:
             chop_vegetable()
-            metrics.incr('vegetable', value=1)
+            metrics.incr("vegetable", value=1)
 
 
 At application startup, configure Markus with the backends you want to use to
@@ -83,24 +85,24 @@ For example, lets configure metrics to publish to logs and Datadog::
         backends=[
             {
                 # Log metrics to the logs
-                'class': 'markus.backends.logging.LoggingMetrics',
+                "class": "markus.backends.logging.LoggingMetrics",
             },
             {
                 # Log metrics to Datadog
-                'class': 'markus.backends.datadog.DatadogMetrics',
-                'options': {
-                    'statsd_host': 'example.com',
-                    'statsd_port': 8125,
-                    'statsd_namespace': ''
+                "class": "markus.backends.datadog.DatadogMetrics",
+                "options": {
+                    "statsd_host": "example.com",
+                    "statsd_port": 8125,
+                    "statsd_namespace": ""
                 }
             }
         ]
     )
 
 
-When you're writing your tests, use the ``MetricsMock`` to make testing easier::
+When you're writing your tests, use the :py:class:`markus.testing.MetricsMock`
+to make testing easier::
 
-    import markus
     from markus.testing import MetricsMock
 
 
@@ -108,8 +110,5 @@ When you're writing your tests, use the ``MetricsMock`` to make testing easier::
         with MetricsMock() as mm:
             # ... Do things that might publish metrics
 
-            # This helps you debug and write your test
-            mm.print_records()
-
             # Make assertions on metrics published
-            assert mm.has_record(markus.INCR, 'some.key', value=1)
+            mm.assert_incr_once("some.key", value=1)

--- a/docs/backends.rst
+++ b/docs/backends.rst
@@ -4,6 +4,9 @@ Backends
 
 Markus comes with several backends. You can also write your own.
 
+.. contents::
+   :local:
+
 
 Logging metrics
 ===============
@@ -58,9 +61,7 @@ Writing your own
    :members: __init__, emit
 
 
-The records that get emitted are ``markus.main.MetricsRecord`` instances.
-
-.. autoclass:: markus.main.MetricsRecord
+The records that get emitted are :py:class:`markus.main.MetricsRecord` instances.
 
 
 Here's an example backend that prints metrics to stdout:

--- a/docs/filters.rst
+++ b/docs/filters.rst
@@ -6,6 +6,9 @@ Markus lets you write and use filters to modify generated metrics.
 
 .. versionadded:: 2.0.0
 
+.. contents::
+   :local:
+
 
 Using filters
 =============

--- a/docs/metricsoverview.rst
+++ b/docs/metricsoverview.rst
@@ -4,6 +4,9 @@ Metrics overview
 
 This chapter covers the different types of metrics and what they're useful for.
 
+.. contents::
+   :local:
+
 
 Counters (incr)
 ===============

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -27,6 +27,14 @@ need to do three things:
 .. autofunction:: markus.get_metrics
 
 
+``markus.main.MetricsRecord``
+=============================
+
+.. autoclass:: markus.main.MetricsRecord
+   :members:
+   :member-order: bysource
+
+
 ``markus.main.MetricsInterface``
 ================================
 

--- a/markus/backends/cloudwatch.py
+++ b/markus/backends/cloudwatch.py
@@ -23,10 +23,10 @@ class CloudwatchMetrics(BackendBase):
     To use, add this to your backends list::
 
         {
-            'class': 'markus.backends.cloudwatch.CloudwatchMetrics',
+            "class": "markus.backends.cloudwatch.CloudwatchMetrics",
         }
 
-    This backend doesn't take any options.
+    This backend doesn"t take any options.
 
     .. Note::
 

--- a/markus/backends/datadog.py
+++ b/markus/backends/datadog.py
@@ -24,11 +24,11 @@ class DatadogMetrics(BackendBase):
     To use, add this to your backends list::
 
         {
-            'class': 'markus.backends.datadog.DatadogMetrics',
-            'options': {
-                'statsd_host': 'localhost',
-                'statsd_port': 8125,
-                'statsd_namespace': '',
+            "class": "markus.backends.datadog.DatadogMetrics",
+            "options": {
+                "statsd_host": "localhost",
+                "statsd_port": 8125,
+                "statsd_namespace": "",
             }
         }
 
@@ -45,7 +45,7 @@ class DatadogMetrics(BackendBase):
 
     * statsd_namespace: the namespace to use for statsd data
 
-      Defaults to ``''``.
+      Defaults to ``""``.
 
 
     .. seealso::

--- a/markus/backends/logging.py
+++ b/markus/backends/logging.py
@@ -17,10 +17,10 @@ class LoggingMetrics(BackendBase):
     To use, add this to your backends list::
 
         {
-            'class': 'markus.backends.logging.LoggingMetrics',
-            'options': {
-                'logger_name': 'markus',
-                'leader': 'METRICS',
+            "class": "markus.backends.logging.LoggingMetrics",
+            "options": {
+                "logger_name": "markus",
+                "leader": "METRICS",
             }
         }
 
@@ -80,11 +80,11 @@ class LoggingRollupMetrics(BackendBase):
     To use, add this to your backends list::
 
         {
-            'class': 'markus.backends.logging.LoggingRollupMetrics',
-            'options': {
-                'logger_name': 'markus',
-                'leader': 'ROLLUP',
-                'flush_interval': 10
+            "class": "markus.backends.logging.LoggingRollupMetrics",
+            "options": {
+                "logger_name": "markus",
+                "leader": "ROLLUP",
+                "flush_interval": 10
             }
         }
 

--- a/markus/backends/statsd.py
+++ b/markus/backends/statsd.py
@@ -24,12 +24,12 @@ class StatsdMetrics(BackendBase):
     To use, add this to your backends list::
 
         {
-            'class': 'markus.backends.statsd.StatsdMetrics',
-            'options': {
-                'statsd_host': 'statsd.example.com',
-                'statsd_port': 8125,
-                'statsd_prefix': None,
-                'statsd_maxudpsize': 512,
+            "class": "markus.backends.statsd.StatsdMetrics",
+            "options": {
+                "statsd_host": "statsd.example.com",
+                "statsd_port": 8125,
+                "statsd_prefix": None,
+                "statsd_maxudpsize": 512,
             }
         }
 
@@ -38,7 +38,7 @@ class StatsdMetrics(BackendBase):
 
     * statsd_host: the hostname for the statsd daemon to connect to
 
-      Defaults to ``'localhost'``.
+      Defaults to ``"localhost"``.
 
     * statsd_port: the port for the statsd daemon to connect to
 
@@ -54,13 +54,13 @@ class StatsdMetrics(BackendBase):
 
     .. Note::
 
-       The StatsdMetrics backend does not support tags. All tags will
-       be dropped when metrics are emitted by this backend.
+       The StatsdMetrics backend does not support tags. All tags will be
+       dropped when metrics are emitted by this backend.
 
     .. Note::
 
-       statsd doesn't support histograms so histogram metrics are
-       reported as timing metrics.
+       statsd doesn't support histograms so histogram metrics are reported as
+       timing metrics.
 
     .. seealso::
 

--- a/markus/main.py
+++ b/markus/main.py
@@ -78,7 +78,7 @@ def configure(backends, raise_errors=False):
 
         markus.configure([
             {
-                'class': 'markus.backends.logging.LoggingMetrics',
+                "class": "markus.backends.logging.LoggingMetrics",
             }
         ])
 
@@ -90,9 +90,9 @@ def configure(backends, raise_errors=False):
 
         markus.configure([
             {
-                'class': 'markus.backends.logging.LoggingMetrics',
-                'options': {
-                    'logger_name': 'metrics'
+                "class": "markus.backends.logging.LoggingMetrics",
+                "options": {
+                    "logger_name": "metrics"
                 }
             }
         ])
@@ -105,8 +105,8 @@ def configure(backends, raise_errors=False):
 
         markus.configure([
             {
-                'class': 'markus.backends.logging.LoggingMetrics',
-                'filters': [AddTagFilter("color:blue")],
+                "class": "markus.backends.logging.LoggingMetrics",
+                "filters": [AddTagFilter("color:blue")],
             }
         ])
 
@@ -159,8 +159,8 @@ def configure(backends, raise_errors=False):
 class MetricsRecord:
     """Record for a single emitted metric.
 
-    :attribute stat_type: the type of the stat ('incr', 'gauge', 'timing',
-        'histogram')
+    :attribute stat_type: the type of the stat ("incr", "gauge", "timing",
+        "histogram")
     :attribute key: the full key for this record
     :attribute value: the value for this record
     :attribute tags: list of tag strings
@@ -295,18 +295,17 @@ class MetricsInterface:
             a value separated by a colon. Tags can make it easier to break down
             metrics for analysis.
 
-            For example ``['env:stage', 'compressed:yes']``.
+            For example ``["env:stage", "compressed:yes"]``.
 
             To pass no tags, either pass an empty list or ``None``.
 
         For example:
 
         >>> import markus
-
-        >>> metrics = markus.get_metrics('foo')
+        >>> metrics = markus.get_metrics("foo")
         >>> def chop_vegetable(kind):
         ...     # chop chop chop
-        ...     metrics.incr('vegetable', value=1)
+        ...     metrics.incr("vegetable", value=1)
 
         You can also use incr to decrement by passing a negative value.
 
@@ -328,17 +327,16 @@ class MetricsInterface:
             a value separated by a colon. Tags can make it easier to break down
             metrics for analysis.
 
-            For example ``['env:stage', 'compressed:yes']``.
+            For example ``["env:stage", "compressed:yes"]``.
 
             To pass no tags, either pass an empty list or ``None``.
 
         For example:
 
         >>> import markus
-
-        >>> metrics = markus.get_metrics('foo')
+        >>> metrics = markus.get_metrics("foo")
         >>> def parse_payload(payload):
-        ...     metrics.gauge('payload_size', value=len(payload))
+        ...     metrics.gauge("payload_size", value=len(payload))
         ...     # parse parse parse
 
         """
@@ -369,7 +367,7 @@ class MetricsInterface:
             a value separated by a colon. Tags can make it easier to break down
             metrics for analysis.
 
-            For example ``['env:stage', 'compressed:yes']``.
+            For example ``["env:stage", "compressed:yes"]``.
 
             To pass no tags, either pass an empty list or ``None``.
 
@@ -377,13 +375,12 @@ class MetricsInterface:
 
         >>> import time
         >>> import markus
-
-        >>> metrics = markus.get_metrics('foo')
+        >>> metrics = markus.get_metrics("foo")
         >>> def upload_file(payload):
         ...     start_time = time.perf_counter()  # this is in seconds
         ...     # upload the file
         ...     timing = (time.perf_counter() - start_time) * 1000.0  # convert to ms
-        ...     metrics.timing('upload_file_time', value=timing)
+        ...     metrics.timing("upload_file_time", value=timing)
 
         .. Note::
 
@@ -419,7 +416,7 @@ class MetricsInterface:
             a value separated by a colon. Tags can make it easier to break down
             metrics for analysis.
 
-            For example ``['env:stage', 'compressed:yes']``.
+            For example ``["env:stage", "compressed:yes"]``.
 
             To pass no tags, either pass an empty list or ``None``.
 
@@ -427,11 +424,10 @@ class MetricsInterface:
 
         >>> import time
         >>> import markus
-
-        >>> metrics = markus.get_metrics('foo')
+        >>> metrics = markus.get_metrics("foo")
         >>> def finalize_sale(cart):
         ...     for item in cart:
-        ...         metrics.histogram('item_cost', value=item.cost)
+        ...         metrics.histogram("item_cost", value=item.cost)
         ...     # finish finalizing
 
         .. Note::
@@ -456,7 +452,7 @@ class MetricsInterface:
             a value separated by a colon. Tags can make it easier to break down
             metrics for analysis.
 
-            For example ``['env:stage', 'compressed:yes']``.
+            For example ``["env:stage", "compressed:yes"]``.
 
             To pass no tags, either pass an empty list or ``None``.
 
@@ -493,15 +489,14 @@ class MetricsInterface:
             a value separated by a colon. Tags can make it easier to break down
             metrics for analysis.
 
-            For example ``['env:stage', 'compressed:yes']``.
+            For example ``["env:stage", "compressed:yes"]``.
 
             To pass no tags, either pass an empty list or ``None``.
 
         For example:
 
         >>> mymetrics = get_metrics(__name__)
-
-        >>> @mymetrics.timer_decorator('long_function')
+        >>> @mymetrics.timer_decorator("long_function")
         ... def long_function():
         ...     # perform some thing we want to keep metrics on
         ...     pass
@@ -559,8 +554,8 @@ def get_metrics(thing="", extra="", filters=None):
     Create a MetricsInterface with the prefix "myapp" and generate a count with
     stat "myapp.thing1" and value 1:
 
-    >>> metrics = get_metrics('myapp')
-    >>> metrics.incr('thing1', value=1)
+    >>> metrics = get_metrics("myapp")
+    >>> metrics.incr("thing1", value=1)
 
     Create a MetricsInterface with the prefix of the Python module it's being
     called in:
@@ -579,7 +574,7 @@ def get_metrics(thing="", extra="", filters=None):
     ...     def __init__(self, myprefix):
     ...         self.metrics = get_metrics(self, extra=myprefix)
     ...
-    >>> foo = Foo('jim')
+    >>> foo = Foo("jim")
 
     Assume that ``Foo`` is defined in the ``myapp`` module. Then this will
     generate the prefix ``myapp.Foo.jim``.

--- a/markus/testing.py
+++ b/markus/testing.py
@@ -40,7 +40,7 @@ class MetricsMock:
                 # Do things that might record metrics here
 
                 # Assert something about the metrics recorded
-                mm.assert_incr_once(stat='some.random.key', value=1)
+                mm.assert_incr_once(stat="some.random.key", value=1)
 
     When using the ``assert_*`` helper methods, if the assertion fails, it'll
     print the MetricsRecords that were emitted to stdout.

--- a/markus/utils.py
+++ b/markus/utils.py
@@ -39,19 +39,29 @@ def generate_tag(key, value=None):
     Examples:
 
     >>> from markus.utils import generate_tag
-    >>> generate_tag('yellow')
+    >>> generate_tag("yellow")
     'yellow'
-    >>> generate_tag('rule', 'is_yellow')
+    >>> generate_tag("rule", "is_yellow")
     'rule:is_yellow'
 
-    Example with ``incr``:
+    Some examples of sanitizing:
+
+    >>> from markus.utils import generate_tag
+    >>> generate_tag("rule", "THIS$#$%^!@IS[]{$}GROSS!")
+    'rule:this_______is_____gross_'
+    >>> generate_tag("host")
+    'host_'
+
+    Example using it with :py:meth:`markus.main.MetricsInterface.incr`:
 
     >>> import markus
     >>> from markus.utils import generate_tag
     >>> mymetrics = markus.get_metrics(__name__)
-
-    >>> mymetrics.incr('somekey', value=1,
-    ...                tags=[generate_tag('rule', 'is_yellow')])
+    >>> mymetrics.incr(
+    ...     "somekey",
+    ...     value=1,
+    ...     tags=[generate_tag("rule", "is_yellow")]
+    ... )
 
     """
     # Verify the types


### PR DESCRIPTION
* fix strings to use double-quotes
* clean up language
* add more class/method linking
* add autodoc for MetricsRecord
* fix `README` which was 10 kinds of wrogn
* fix testing examples
* add some table-of-contents to long pages
* add some additional `generate_tag()` examples