### PR TITLE
Add pytest plugin, remove pytest import from ``__init__.py``

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ EXTRAS_REQUIRE = {
     "datadog": ["datadog"],
     "statsd": ["statsd"],
     "dev": [
-        "black==21.9b0",
+        "black==22.3.0",
         "check-manifest==0.47",
         "flake8==4.0.1",
         "freezegun==1.1.0",

--- a/setup.py
+++ b/setup.py
@@ -96,4 +96,7 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
     ],
+    entry_points={
+        "pytest11": ["markus=markus.pytest_plugin"],
+    },
 )

--- a/src/markus/__init__.py
+++ b/src/markus/__init__.py
@@ -2,14 +2,6 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-try:
-    # Enable pytest assert rewriting for better assert debugging
-    import pytest
-
-    pytest.register_assert_rewrite("markus.testing")
-except ImportError:
-    pass
-
 from markus.main import configure, get_metrics  # noqa
 
 INCR = "incr"

--- a/src/markus/pytest_plugin.py
+++ b/src/markus/pytest_plugin.py
@@ -1,0 +1,3 @@
+import pytest
+
+pytest.register_assert_rewrite("markus.testing")

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ install_command = pip install {packages}
 extras = dev,datadog,statsd
 commands =
     pytest tests/
-    pytest --doctest-modules src/
+    pytest --doctest-modules --pyargs markus
 
 [testenv:py37-lint]
 basepython = python3.7


### PR DESCRIPTION
Add a `pytest_plugin.py` file, referenced from `setup.py`, that `pytest` will load when it loads `markus`. This allows the re-written assertions without importing `pytest` in ``__init__.py``, fixing #95.

I also started adding a fixture, but decided to remove it to make the PR more focused:

```python
from .testing import MetricsMock

@pytest.fixture(scope="function")
def capmetrics():
    with MetricsMock() as capmetrics:
        yield capmetrics
```

I was getting this error:

```
py37-lint run-test: commands[0] | black --check --target-version=py37 --line-length=88 src tests
Traceback (most recent call last):
  File "/Users/john/src/markus/.tox/py37-lint/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/Users/john/src/markus/.tox/py37-lint/lib/python3.7/site-packages/black/__init__.py", line 1282, in patched_main
    patch_click()
  File "/Users/john/src/markus/.tox/py37-lint/lib/python3.7/site-packages/black/__init__.py", line 1268, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/Users/john/src/markus/.tox/py37-lint/lib/python3.7/site-packages/click/__init__.py)
ERROR: InvocationError for command /Users/john/src/markus/.tox/py37-lint/bin/black --check --target-version=py37 --line-length=88 src tests (exited with code 1)
```

This [StackOverflow answer](https://stackoverflow.com/a/71674345/10612) suggested updating to Black 22.3.0

After adding the pytest entrypoint, I was getting failures with ``pytest --doctest-modules src/``:

```
________________________________________________ ERROR collecting src/markus/filters.py ________________________________________________
.tox/py39/lib/python3.9/site-packages/_pytest/runner.py:311: in from_call
    result: Optional[TResult] = func()
.tox/py39/lib/python3.9/site-packages/_pytest/runner.py:341: in <lambda>
    call = CallInfo.from_call(lambda: list(collector.collect()), "collect")
.tox/py39/lib/python3.9/site-packages/_pytest/doctest.py:532: in collect
    module = import_path(self.fspath)
.tox/py39/lib/python3.9/site-packages/_pytest/pathlib.py:544: in import_path
    raise ImportPathMismatchError(module_name, module_file, path)
E   _pytest.pathlib.ImportPathMismatchError: ('markus.filters', '/Users/john/src/markus/.tox/py39/lib/python3.9/site-packages/markus/filters.py', PosixPath('/Users/john/src/markus/src/markus/filters.py'))
```

As suggested by others, changing the command to ``pytest --doctest-modules --pyargs markus`` worked, to tell pytest to use the installed module versus the source code file and avoid the import mismatch.


