### PR TITLE
Redo dev environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Update pip and install dev requirements
         run: |
           python -m pip install --upgrade pip
-          pip install '.[dev,datadog.statsd]'
+          pip install -r requirements-dev.txt
 
       - name: Test
         run: tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -39,7 +39,7 @@ Run::
     ...
 
     # Install Markus and dev requirements
-    $ pip install -e '.[dev,datadog,statsd]'
+    $ pip install -r requirements-dev.txt
 
 
 Documentation

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean:  ## Clean build artifacts
 .PHONY: lint
 lint:  ## Lint and black reformat files
 	black --target-version=py37 --line-length=88 src setup.py tests
-	tox -e py37-lint
+	tox -e py37-flake8
 
 .PHONY: test
 test:  ## Run tox to test across supported Python versions
@@ -26,7 +26,7 @@ test:  ## Run tox to test across supported Python versions
 checkrot:  ## Check package rot for dev dependencies
 	python -m venv ./tmpvenv/
 	./tmpvenv/bin/pip install -U pip
-	./tmpvenv/bin/pip install '.[dev,datadog,statsd]'
+	./tmpvenv/bin/pip install -r requirements-dev.txt
 	./tmpvenv/bin/pip list -o
 	rm -rf ./tmpvenv/
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,13 @@
+-e .[datadog,statsd]
+
+black==22.10.0
+build==0.8.0
+check-manifest==0.48
+freezegun==1.2.2
+pytest==7.2.0
+Sphinx==5.3.0
+sphinx-rtd-theme==1.0.0
+tox==3.27.0
+tox-gh-actions==2.10.0
+twine==4.0.1
+wheel==0.38.2

--- a/requirements-flake8.txt
+++ b/requirements-flake8.txt
@@ -1,0 +1,3 @@
+# Requirements file for running flake8.
+
+flake8==5.0.4

--- a/setup.py
+++ b/setup.py
@@ -7,27 +7,7 @@
 
 import os
 import re
-import sys
 from setuptools import find_packages, setup
-from setuptools.command.test import test as TestCommand
-
-
-class PyTest(TestCommand):
-    user_options = [("pytest-args=", "a", "Arguments to pass to pytest")]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def run_tests(self):
-        import shlex
-
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-
-        pytest_args = shlex.split(self.pytest_args) if self.pytest_args else []
-        errno = pytest.main(pytest_args)
-        sys.exit(errno)
 
 
 def get_version():
@@ -46,20 +26,8 @@ INSTALL_REQUIRES = []
 EXTRAS_REQUIRE = {
     "datadog": ["datadog"],
     "statsd": ["statsd"],
-    "dev": [
-        "black==22.3.0",
-        "check-manifest==0.48",
-        "flake8==4.0.1",
-        "freezegun==1.2.1",
-        "pytest==7.1.2",
-        "Sphinx==4.3.0",
-        "tox==3.25.0",
-        "tox-gh-actions==2.9.1",
-        "twine==4.0.0",
-        "wheel==0.37.1",
-    ],
 }
-TESTS_REQUIRES = ["pytest"]
+
 
 setup(
     name="markus",
@@ -76,10 +44,8 @@ setup(
     },
     install_requires=INSTALL_REQUIRES,
     extras_require=EXTRAS_REQUIRE,
-    tests_requires=TESTS_REQUIRES,
     packages=find_packages(where="src"),
     package_dir={"": "src"},
-    cmdclass={"test": PyTest},
     include_package_data=True,
     license="MPLv2",
     zip_safe=False,

--- a/src/markus/pytest_plugin.py
+++ b/src/markus/pytest_plugin.py
@@ -1,3 +1,8 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
 import pytest
+
 
 pytest.register_assert_rewrite("markus.testing")

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,30 @@
 [tox]
-envlist = py37,py38,py39,py310,py311,py37-lint
+envlist = py37,py38,py39,py310,py311,py37-black,py37-flake8
+
+[gh-actions]
+python =
+    3.7: py37
+    3.8: py38
+    3.9: py39
+    3.10: py310
+    3.11: py311
 
 [testenv]
-install_command = pip install {packages}
-extras = dev,datadog,statsd
+deps = -rrequirements-dev.txt
+extras = datadog,statsd
 commands =
     pytest tests/
     pytest --doctest-modules --pyargs markus
 
-[testenv:py37-lint]
+[testenv:py37-black]
 basepython = python3.7
 changedir = {toxinidir}
-commands =
-    black --check --target-version=py37 --line-length=88 src setup.py tests
-    flake8 src setup.py tests
+commands = black --check --target-version=py37 --line-length=88 src setup.py tests
+
+[testenv:py37-flake8]
+# flake8 pins importlib_metadata for reasons so we run this in a different
+# environment.
+deps = -rrequirements-flake8.txt
+basepython = python3.7
+changedir = {toxinidir}
+commands = flake8 src setup.py tests


### PR DESCRIPTION
This switches us back to using a requirements-dev.txt file for dev requirements.

This updates the dev requirements to latest versions.

This splits off flake8 to a separate environment because it conflicts with Sphinx.