### PR TITLE
Add origin_detection_enabled support for datadog backend (#108)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ def get_file(fn):
 
 INSTALL_REQUIRES = []
 EXTRAS_REQUIRE = {
-    "datadog": ["datadog"],
+    "datadog": ["datadog>=0.45.0"],
     "statsd": ["statsd"],
 }
 

--- a/src/markus/backends/datadog.py
+++ b/src/markus/backends/datadog.py
@@ -47,6 +47,10 @@ class DatadogMetrics(BackendBase):
 
       Defaults to ``""``.
 
+    * origin_detection_enabled: whether or not the client should fill the
+      container field (part of datadog protocol v1.2).
+
+      Defaults to ``False``.
 
     .. seealso::
 
@@ -61,18 +65,30 @@ class DatadogMetrics(BackendBase):
         self.host = options.get("statsd_host", "localhost")
         self.port = options.get("statsd_port", 8125)
         self.namespace = options.get("statsd_namespace", "")
+        self.origin_detection_enabled = options.get("origin_detection_enabled", False)
 
-        self.client = self._get_client(self.host, self.port, self.namespace)
-        logger.info(
-            "%s configured: %s:%s %s",
+        self.client = self._get_client(
+            host=self.host,
+            port=self.port,
+            namespace=self.namespace,
+            origin_detection_enabled=self.origin_detection_enabled,
+        )
+        logger.debug(
+            "%s configured: %s:%s %s %s",
             self.__class__.__name__,
             self.host,
             self.port,
             self.namespace,
+            self.origin_detection_enabled,
         )
 
-    def _get_client(self, host, port, namespace):
-        return DogStatsd(host=host, port=port, namespace=namespace)
+    def _get_client(self, host, port, namespace, origin_detection_enabled):
+        return DogStatsd(
+            host=host,
+            port=port,
+            namespace=namespace,
+            origin_detection_enabled=origin_detection_enabled,
+        )
 
     def emit(self, record):
         stat_type_to_fun = {

--- a/src/markus/backends/statsd.py
+++ b/src/markus/backends/statsd.py
@@ -80,7 +80,7 @@ class StatsdMetrics(BackendBase):
         self.client = self._get_client(
             self.host, self.port, self.prefix, self.maxudpsize
         )
-        logger.info(
+        logger.debug(
             "%s configured: %s:%s %s",
             self.__class__.__name__,
             self.host,

--- a/tests/test_datadog.py
+++ b/tests/test_datadog.py
@@ -46,17 +46,28 @@ def test_default_options(mockdogstatsd):
 
     # NOTE(willkg): ddm.client is the mock instance
     assert ddm.client.initargs == ()
-    assert ddm.client.initkwargs == {"host": "localhost", "port": 8125, "namespace": ""}
+    assert ddm.client.initkwargs == {
+        "host": "localhost",
+        "port": 8125,
+        "namespace": "",
+        "origin_detection_enabled": False,
+    }
 
 
 def test_options(mockdogstatsd):
     ddm = datadog.DatadogMetrics(
-        {"statsd_host": "example.com", "statsd_port": 5000, "statsd_namespace": "joe"}
+        options={
+            "statsd_host": "example.com",
+            "statsd_port": 5000,
+            "statsd_namespace": "joe",
+            "origin_detection_enabled": True,
+        }
     )
 
     assert ddm.host == "example.com"
     assert ddm.port == 5000
     assert ddm.namespace == "joe"
+    assert ddm.origin_detection_enabled is True
 
     # NOTE(willkg): ddm.client is the mock instance
     assert ddm.client.initargs == ()
@@ -64,6 +75,7 @@ def test_options(mockdogstatsd):
         "host": "example.com",
         "port": 5000,
         "namespace": "joe",
+        "origin_detection_enabled": True,
     }
 
 


### PR DESCRIPTION
This adds `origin_detection_enabled` support and defaults it to False which works better if you're not using the Datadog agent.

This ups the datadog dependency to 0.45.0 which is the version that added the container id stuff, or higher. I thought about making the code support <0.45.0 and >=0.45.0, but then decided not to. If that turns out to be an error, we can add support later. I'll make sure to call it out in the notes and maybe even consider it a backwards-incompatible change causing me to increase the major version.