### PR TITLE
Add .extend_prefix() to hone a MetricsInterface prefix (#142)

### DIFF
--- a/src/markus/filters.py
+++ b/src/markus/filters.py
@@ -26,6 +26,9 @@ class AddTagFilter(MetricsFilter):
     def __init__(self, tag):
         self.tag = tag
 
+    def __repr__(self):
+        return f"<AddTagFilter {self.tag}>"
+
     def filter(self, record):
         record.tags.append(self.tag)
         return record

--- a/src/markus/main.py
+++ b/src/markus/main.py
@@ -205,6 +205,9 @@ class MetricsFilter:
 
     """
 
+    def __repr__(self):
+        return "<MetricsFilter>"
+
     def filter(self, record):
         """Filter a record
 
@@ -283,6 +286,14 @@ class MetricsInterface:
             # backends
             fresh_record = record.__copy__()
             backend.emit_to_backend(fresh_record)
+
+    def extend_prefix(self, prefix):
+        prefix = prefix.strip(".")
+
+        return MetricsInterface(
+            f"{self.prefix}.{prefix}",
+            filters=list(self.filters),
+        )
 
     def incr(self, stat, value=1, tags=None):
         """Incr is used for counting things.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -36,8 +36,32 @@ class Foo:
         ("foo", "namespace1", "foo.namespace1"),
     ],
 )
-def test_get_metrics(thing, extra, expected):
+def test_get_metrics_prefix(thing, extra, expected):
     assert get_metrics(thing, extra=extra).prefix == expected
+
+
+def test_metricsinterface_extend_prefix():
+    metrics = get_metrics("a")
+    sub_metrics = metrics.extend_prefix("b")
+    assert sub_metrics.prefix == "a.b"
+    assert sub_metrics.filters == []
+
+    sub_metrics = metrics.extend_prefix(".b.")
+    assert sub_metrics.prefix == "a.b"
+    assert sub_metrics.filters == []
+
+    tag_filter_host_foo = AddTagFilter("host:foo")
+
+    metrics.filters.append(tag_filter_host_foo)
+    sub_metrics = metrics.extend_prefix("b")
+    assert sub_metrics.prefix == "a.b"
+    assert sub_metrics.filters == [tag_filter_host_foo]
+
+    tag_filter_env_prod = AddTagFilter("env:prod")
+    # Add a second tag filter and make sure the two lists are independent
+    metrics.filters.append(tag_filter_env_prod)
+    assert metrics.filters == [tag_filter_host_foo, tag_filter_env_prod]
+    assert sub_metrics.filters == [tag_filter_host_foo]
 
 
 def test_dunders():


### PR DESCRIPTION
This makes it possible to iteratively hone a MetricsInterface prefix. So you can do things like this:

```
    # prefix here is "module"
    metrics = markus.get_metrics("module")

    # prefix here is "module.somefunc"
    func_metrics = metrics.extend_prefix("somefunc")
```

Fixes #142 