### PR TITLE
Fix docs building

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,4 +14,9 @@ sphinx:
 
 python:
   install:
-    - requirements: requirements-dev.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - datadog
+        - dev
+        - statsd


### PR DESCRIPTION
readthedocs was configured to look at a file that we don't have anymore. This switches it to install the package with required extras.