### PR TITLE
Rework LoggingBackend and timestamps (#11)

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,39 @@ History
 
 * Dropped support for Python 3.8 (#160)
 
+* Changed timestamp field in LoggingBackend. The LoggingBackend now defaults to
+  not emitting a timestamp at all. If you would like a timestamp, you can
+  provide the ``"timestamp_mode"`` option with either ``"utc"`` for UTC
+  timestamps or ``"local"`` for local timezone timestamps.
+
+  No timestamp example::
+
+      LoggingBackend()
+
+  emits lines like::
+
+      METRICS|histogram|foo|4321|#key1:val
+
+  ``"utc"`` timestamp mode example::
+
+      LoggingBackend(options={"timestamp_mode": "utc"})
+
+  emits lines like::
+
+      METRICS|2017-03-06T11:30:00+00:00:00|histogram|foo|4321|#key1:val
+
+  ``"local"`` timestamp mode example::
+
+      LoggingBackend(options={"timestamp_mode": "local"})
+
+  emits lines like::
+
+      METRICS|2017-03-06T11:30:00|histogram|foo|4321|#key1:val
+
+  If you want the original behavior, add set ``timestamp_mode`` to ``local``.
+  (#11)
+
+
 
 5.0.0 (June 24th, 2024)
 -----------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,14 +12,14 @@ History
 
 * Dropped support for Python 3.8 (#160)
 
-* Changed timestamp field in LoggingBackend. The LoggingBackend now defaults to
-  not emitting a timestamp at all. If you would like a timestamp, you can
-  provide the ``"timestamp_mode"`` option with either ``"utc"`` for UTC
+* Changed timestamp field in ``LoggingMetrics``. The ``LoggingMetrics`` now
+  defaults to not emitting a timestamp at all. If you would like a timestamp,
+  you can provide the ``"timestamp_mode"`` option with either ``"utc"`` for UTC
   timestamps or ``"local"`` for local timezone timestamps.
 
   No timestamp example::
 
-      LoggingBackend()
+      LoggingMetrics()
 
   emits lines like::
 
@@ -27,7 +27,7 @@ History
 
   ``"utc"`` timestamp mode example::
 
-      LoggingBackend(options={"timestamp_mode": "utc"})
+      LoggingMetrics(options={"timestamp_mode": "utc"})
 
   emits lines like::
 
@@ -35,7 +35,7 @@ History
 
   ``"local"`` timestamp mode example::
 
-      LoggingBackend(options={"timestamp_mode": "local"})
+      LoggingMetrics(options={"timestamp_mode": "local"})
 
   emits lines like::
 


### PR DESCRIPTION
This adds a new "timestamp_mode" which changes the behavior of the timestamp in the logged output.

* "utc": inserts a UTC timestamp
* "local": inserts a local timezone timestamp
* anything: doesn't insert a timestamp at all

In the cases where I'm using Markus in a local dev environment for service development, the logging framework is already configured with a timestamp, so having Markus' LoggingBackend also include a timestamp is redundant and not wildly helpful. Thus I wanted to include a "no timestamp" option.

For when the user wants a timestamp, it seemed prudent to support both UTC and local timezone timestamps.

Also, timestamps are now emitted in isoformat.

Fixes #11.