### PR TITLE
docs: fix 1 typo(s) in justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -34,7 +34,7 @@ clean:
     find src/markus/ tests/ -name __pycache__ | xargs rm -rf
     find src/markus/ tests/ -name '*.pyc' | xargs rm -rf
 
-# Build files for relase
+# Build files for release
 build: devenv
     rm -rf build/ dist/
     uv run python -m build


### PR DESCRIPTION
## Summary

Fixed 1 typo(s) found in documentation files while reading the docs.

## Changes

- `justfile` L37: `relase` → `release`

## Type of change

- [x] Documentation fix (typo/spelling only)

## Checklist

- [x] I have read the contributing guidelines
- [x] My changes follow the existing documentation style
- [x] No code changes — documentation only

---

*Found via automated spell-check. Please review each fix carefully. Happy to adjust if any correction doesn't fit the intended meaning.*
